### PR TITLE
The import command and a sample of how it can be used.

### DIFF
--- a/src/Commands/ImportCommand.php
+++ b/src/Commands/ImportCommand.php
@@ -1,0 +1,164 @@
+<?php
+
+
+namespace App\Console\Commands\Import;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\Console\Helper\ProgressBar;
+
+abstract class ImportCommand extends Command
+{
+    /**
+     * The maximum amount of memory you are willing to let this script take, in some cases depending on
+     * speed and cpu's in the sever or dev machine you may want to increase this to 8G or 16G etc...
+     *
+     * @var string $memoryLimit
+     */
+    protected string $memoryLimit = '1G';
+    
+    /**
+     * When you are pulling items from one database into another, I've left the destination as the default access
+     * and the explicit connection as the original database. It's also not a bad idea to make sure you are working
+     * with a copy of your original database, because sometimes its quicker to do repair transforms on it than
+     * your target. And you shouldn't do that without first making a copy and calling it something like export :)
+     *
+     * @var string
+     */
+    protected string $originalDatabase = 'export';
+    
+    /**
+     * User for Notes with helper commands
+     * @var string
+     */
+    protected string $model = '';
+    
+    /**
+     * This is for speed tuning, you want to build up piles of data and batch it.You really don't need to worry about
+     * this until 100,000 records+. It's once your migrations take minutes and hours. I'm sure there are people who
+     * take days, but I've never worked anywhere that big.
+     *
+     * @var int $saveEvery
+     */
+    protected int $saveEvery = 1000;
+    
+    /**
+     * I just use this often to leave a visual log on the screen, as data is moving all over the place, especially if
+     * if you run into an issue you can have a visual cue on screen of how far along you are.
+     *
+     * @var int $step
+     */
+    protected int $step = 1;
+    
+    
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        
+        $this->setup();
+        
+        
+    }
+    
+    /**
+     * This is mysql specific, you'd need some pgsql or other guru to help with another way but there are a huge number
+     * of people running mysql so you might find this helpful as a starting point. The key to all this is like a lazy
+     * collection. You need to force the data to get streamed over a connection from and to the database and clear out
+     * memory as you use it.
+     */
+    public function setup()
+    {
+        // Prepare the database to run in non buffered mode.
+        DB::connection($this->originalDatabase)
+            ->getPdo()->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+        
+        // Vastly increase memory for the following operation
+        ini_set('memory_limit', $this->memoryLimit);
+    }
+    
+    /**
+     * Make a progress bar, Some of the transforms can take 1 - 30 minutes, staring at a blank screen is not a great
+     * idea in those cases.
+     *
+     * @param $builder
+     * @param $model
+     * @param string $time
+     *
+     * @return ProgressBar
+     */
+    public function createProgressBar($builder, $model, $time = '10 - 20 seconds'): ProgressBar
+    {
+        $this->model = $model;
+        // Create a progress bar
+        $this->info('Collecting ' . $model . ', the initial count will take ' . $time . ' ...');
+        
+        $count = $builder->count();
+        
+        $this->info('Found ' . $count . ' ' . $model);
+        
+        $bar = $this->output->createProgressBar($count);
+        $bar->start();
+        
+        return $bar;
+    }
+    
+    
+    public function updateStepWithMessage(string $message): void
+    {
+        $this->info($this->step++ . '. ' . $message);
+    }
+    
+    public function closeProgressBar($bar)
+    {
+        $bar->finish();
+        $this->info("\n" . $this->model . " Import Completed");
+    }
+    
+    
+    /**
+     * Keep track of where you are in the process if it's a long set of transforms. Break it up into multiple commands.
+     * It will relinquish memory and give you better backup points in case something goes wrong you don't have to start
+     * at the beginning.
+     */
+    public function nextCommand()
+    {
+        $steps = collect([
+            'import:prep',
+            'import:users',
+            'import:categories',
+            'import:stuff',
+            'import:things',
+            'import:more-things',
+            'import:etc...',
+        ]);
+        
+        $current = $steps->flip()->first(fn ($value, $key) => $key === $this->signature);
+        if ( $current < $steps->count() - 1 ) {
+            $this->info('The next step is ');
+            $this->info('php artisan ' . $steps[ $current + 1 ]);
+        } else {
+            $this->info('All done. Please do both visual and database tests');
+        }
+    }
+    
+    /**
+     * When all else fails, open up tinker, and purge some things... ImportCommand::truncateTable('users');
+     * @param $table
+     */
+    public static function truncateTable($table)
+    {
+        Schema::disableForeignKeyConstraints();
+        
+        DB::table($table)->truncate();
+        
+        Schema::enableForeignKeyConstraints();
+    }
+    
+    abstract public function handle();
+}

--- a/src/Commands/UsersCommand.php
+++ b/src/Commands/UsersCommand.php
@@ -1,0 +1,216 @@
+<?php
+
+
+namespace App\Console\Commands\Import;
+
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+
+class UsersCommand extends ImportCommand
+{
+    
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'import:users';
+    
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This will import cleaned users from the ############ database, to a mew laravel system';
+    
+    /**
+     * Something needed for this implementation, an enum that I'm moving into the codebase.
+     * @var array|int[]
+     */
+    protected array $viewables = [
+        'everyone' => 1,
+        'members'  => 2,
+        'followed' => 3,
+        'none'     => 4,
+    ];
+    
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+    
+    public function handle()
+    {
+        $this->processUsers();
+        
+        $this->nextCommand();
+    }
+    
+    
+    public function cleanLinks(string $var): string
+    {
+        return str($var)
+            ->replace("[URL='http", '[URL="http')
+            ->replace("']", '"]');
+    }
+    
+    
+    
+    public function processJsonField($field, $model, $extra): \Illuminate\Support\Collection
+    {
+        $jsonObject = object_get($model, $field);
+        
+        $array = $extra->jsonserialize();
+        
+        $list = json_decode($jsonObject, true) ?? [];
+        
+        foreach ( $list as $key => $value ) {
+            $compValue = strtolower(trim($value));
+            if ( strlen($compValue) == 0 ) {
+                continue;
+            }
+            
+            
+            if ( in_array($compValue, [ 'null', 'invalid' ]) ) {
+                continue;
+            }
+            
+            
+            $array[ $field ][ $key ] = $value;
+        }
+        
+        return collect($array);
+    }
+    
+    public function pushFieldToExtra($field, $model, $extra, $value = null): \Illuminate\Support\Collection
+    {
+        if ( is_null($value) ) {
+            $value = data_get($model, $field, "");
+        }
+        
+        $array = $extra->jsonserialize();
+        
+        if ( in_array(strtolower(trim($value)), [ 'null', 'invalid' ]) ) {
+            $value = "";
+        }
+        
+        $array[ $field ] = $value;
+        
+        return collect($array);
+    }
+    
+    public function processUsers()
+    {
+        $this->updateStepWithMessage('Importing Users');
+        
+        $builder = DB::connection($this->connection)
+            ->table('sys_user')
+            ->select(DB::raw('sys_user.user_id as id, email, username, register_date, sys_user_authenticate.data, last_activity,
+            timezone,is_moderator, is_admin, is_banned, visible, activity_visible, privacy_policy_accepted,terms_accepted,
+            dob_day,dob_month,dob_year,signature,website,location,about,custom_fields,connected_accounts,following,ignored,
+            allow_view_profile,allow_send_personal_conversation,
+            show_dob_year, show_dob_date,content_show_signature,creation_watch_state,interaction_watch_state,email_on_conversation'))
+            ->leftJoin('sys_user_authenticate', 'sys_user.user_id', '=', 'sys_user_authenticate.user_id')
+            ->leftJoin('sys_user_profile', 'sys_user.user_id', '=', 'sys_user_profile.user_id')
+            ->leftJoin('sys_user_privacy', 'sys_user.user_id', '=', 'sys_user_privacy.user_id')
+            ->leftJoin('sys_user_option', 'sys_user.user_id', '=', 'sys_user_option.user_id')
+            ->orderBy('sys_user.user_id');
+        
+        
+        // Create a progress bar
+        $bar = $this->createProgressBar($builder, 'Users');
+        
+        $out  = [];
+        $loop = 0;
+     
+        foreach ( $builder->cursor() as $user ) {
+            $bar->advance();
+            
+            $extra = collect();
+            
+            $extra = $this->pushFieldToExtra('location', $user, $extra);
+            $extra = $this->processJsonField('custom_fields', $user, $extra);
+            $extra = $this->processJsonField('connected_accounts', $user, $extra);
+            
+            
+            $password = 'some hash';
+            if ( $user->data ) {
+                $data = unserialize($user->data);
+                if ( isset($data['hash']) ) {
+                    $password = $data['hash'];
+                }
+            }
+            unset($data);
+            $date = Carbon::createFromTimestampUTC($user->register_date);
+            
+            if ( empty($user->email) ) {
+                continue;
+            }
+            
+            $out[] = [
+                'id'                => $user->id,
+                'name'              => $user->username,
+                'email'             => $user->email,
+                'email_verified_at' => $date,
+                'password'          => $password,
+                'created_at'        => $date,
+                
+                //Additional Fields
+                'updated_at'        =>
+                    ( $user->last_activity ?
+                        Carbon::createFromTimestamp($user->last_activity) : null ),
+                
+                'is_moderator'        => $user->is_moderator,
+                'is_admin'            => $user->is_admin,
+                'is_banned'           => $user->is_banned,
+                'is_visible'          => $user->visible,
+                'activity_is_visible' => $user->activity_visible,
+                'avatar'              => null,
+                
+                'email_on_dms'             => $user->email_on_conversation,
+                'allow_view_profile'    => $this->viewables[ $user->allow_view_profile ],
+                'allow_direct_messages' => $this->viewables[ $user->allow_send_personal_conversation ],
+                
+                'privacy_policy_accepted' =>
+                    ( $user->privacy_policy_accepted ?
+                        Carbon::createFromTimestamp($user->privacy_policy_accepted) : null ),
+                'terms_accepted'          =>
+                    ( $user->terms_accepted ?
+                        Carbon::createFromTimestamp($user->terms_accepted) : null ),
+                'extra'                   => $extra->toJson(),
+                
+                // look at warning points and reaction score once this has been implemented.
+            ];
+            
+            unset($extra);
+            
+            //finish processing the output
+            $loop++;
+            
+            //if we've hit the buffer number of users to insert batch insert them, otherwise keep building the loop!
+            if ( $loop >= $this->saveEvery ) {
+                User::insert($out);
+                
+                $out  = [];
+                $loop = 0;
+            }
+        }
+        
+        // when you are done, if there are any left over unprocessed users make sure to insert them now.
+        if ( $loop < $this->saveEvery ) {
+            User::insert($out);
+        }
+        
+        $this->closeProgressBar($bar);
+    }
+}


### PR DESCRIPTION
Ok, So this IS NOT a PR to merge but more of a sample that you can pick apart and use whatever you like or toss completely. 

To test it out, make a database with some data and populate it with 1-100 million rows of random data and relationships. Anything that will strain the computer that you are on so queries actually take a few seconds. 2-5 seconds is a good benchmark for unoptimized versions. Try and transform with chunk and normally it will take long, really long like possibly minutes or hours before it either comes through or fails based on your memory cpu limits.

Transforms using this strategy will still take a bit of time but I cut this migration down by 80%, enough to keep it complex  but basically easy enough that most Laravel beginners could follow it without any real questions. This should complete on 1 million users in about 30 - 60 seconds. You could probably speed it up or slow it down by changing saveEvery to 100 or 10 or even 1  and playing with RAM etc...

Also in this example I didn't use  the screen annotation function but I normally using it when purging key mismatches or looking for dead data in a function 

`$this->updateStepWithMessage("Updating all the matched {$foreignKey}s in {$inTable}");`

will read something like 

5. Updating all the matched user_ids in posts

Hope you find this useful. If you find better faster ways to do this please let me know :)